### PR TITLE
Specify https protocol for links to spdx.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Returns links for standard licenses on spdx.org:
 ```javascript
 assert.deepEqual(
   spdxToHTML('MIT'),
-  '<a href="http://spdx.org/licenses/MIT.html">MIT</a>'
+  '<a href="https://spdx.org/licenses/MIT.html">MIT</a>'
 )
 ```
 
@@ -36,9 +36,9 @@ Constructs English disjunctions for multilicensing expressions:
 assert.deepEqual(
   spdxToHTML('(MPL-2.0 OR GPL-2.0+)'),
   (
-    '<a href="http://spdx.org/licenses/MPL-2.0.html">MPL-2.0</a>' +
+    '<a href="https://spdx.org/licenses/MPL-2.0.html">MPL-2.0</a>' +
     ' or ' +
-    '<a href="http://spdx.org/licenses/GPL-2.0.html">GPL-2.0</a> or newer'
+    '<a href="https://spdx.org/licenses/GPL-2.0.html">GPL-2.0</a> or newer'
   )
 )
 ```
@@ -49,7 +49,7 @@ Describes ranges and exceptions:
 assert.deepEqual(
   spdxToHTML('(GPL-2.0+ WITH Bison-exception-2.2)'),
   (
-    '<a href="http://spdx.org/licenses/GPL-2.0.html">GPL-2.0</a>' +
+    '<a href="https://spdx.org/licenses/GPL-2.0.html">GPL-2.0</a>' +
     ' or newer' +
     ' with Bison-exception-2.2'
   )

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function render (parsed) {
       return 'License Reference "' + parsed.license + '"'
     } else {
       return (
-        '<a href="http://spdx.org/licenses/' + parsed.license + '.html">' +
+        '<a href="https://spdx.org/licenses/' + parsed.license + '.html">' +
           parsed.license +
         '</a>' +
         (parsed.plus ? ' or newer' : '') +


### PR DESCRIPTION
Does what it says on the tin - spdx.org supports SSL and it'd be good to use it.